### PR TITLE
updated negative(s) to avoid for diplos in riven guides, also changed…

### DIFF
--- a/advanced/riven-guide.md
+++ b/advanced/riven-guide.md
@@ -46,13 +46,13 @@ Ideally, you have Toxin and Cold on your Riven, but if you have only one of them
 - Crit Chance
 
 **Negatives:**
-Avoid Damage, Crit Damage, Corpus, Fire Rate, Crit Chance, Multishot
+Avoid Damage, Crit Damage, Corpus, Fire Rate, Crit Chance, Multishot, Physical Damage (IPS)
 
 ## **Zaw with Attack Speed**
 
 - Crit Damage: Yes.
 - Damage: Yes.
-- Element: Toxin/Heat/Electricity will be the most flexible.
+- Element: Toxin/Heat/Cold will be the most flexible.
 - Crit Chance: Has to be at least 212.5% to reach 100% CC for consistency.
 - Faction Contagion is OP and grades don't matter, except for CC. On a Volt with Eclipse and Shield, only an attack speed riven makes a difference, although very small and usually not noticeable, can run rivenless otherwise. But this doesn't mean you should be intentionally trying to decrease your damage by getting bad grades, mainly because of future disposition changes.
 


### PR DESCRIPTION
… zaw from elec to cold in the same section